### PR TITLE
Fix for SmartAI Errors shown in the log

### DIFF
--- a/CreapyJaden.sql
+++ b/CreapyJaden.sql
@@ -17,7 +17,7 @@ SET
 @Type       := 7,
 @TypeFlags  := 0,
 @FlagsExtra := 2,
-@AIName     := "SmartAI",
+@AIName     := "",
 @Script     := "";
 
 -- NPC

--- a/CreapyJaden.sql
+++ b/CreapyJaden.sql
@@ -30,7 +30,7 @@ INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`,
 (@Entry, 0, @Model, @Scale, 1);
 
 -- ITEM PRICES
-UPDATE item_template SET BuyPrice = 1000 WHERE entry = 2318;
+UPDATE item_template SET BuyPrice = 100 WHERE entry = 2318;
 
 -- NPC ITEMS
 DELETE FROM npc_vendor WHERE entry = @Entry;

--- a/CunningJim.sql
+++ b/CunningJim.sql
@@ -17,7 +17,7 @@ SET
 @Type       := 7,
 @TypeFlags  := 0,
 @FlagsExtra := 2,
-@AIName     := "SmartAI",
+@AIName     := "",
 @Script     := "";
 
 -- NPC

--- a/EternalJerrik.sql
+++ b/EternalJerrik.sql
@@ -17,7 +17,7 @@ SET
 @Type       := 7,
 @TypeFlags  := 0,
 @FlagsExtra := 2,
-@AIName     := "SmartAI",
+@AIName     := "",
 @Script     := "";
 
 -- NPC

--- a/GlitteryJason.sql
+++ b/GlitteryJason.sql
@@ -17,7 +17,7 @@ SET
 @Type       := 7,
 @TypeFlags  := 0,
 @FlagsExtra := 2,
-@AIName     := "SmartAI",
+@AIName     := "",
 @Script     := "";
 
 -- NPC

--- a/GreedyJoe.sql
+++ b/GreedyJoe.sql
@@ -17,7 +17,7 @@ SET
 @Type       := 7,
 @TypeFlags  := 0,
 @FlagsExtra := 2,
-@AIName     := "SmartAI",
+@AIName     := "",
 @Script     := "";
 
 -- NPC

--- a/GreenJack.sql
+++ b/GreenJack.sql
@@ -17,7 +17,7 @@ SET
 @Type       := 7,
 @TypeFlags  := 0,
 @FlagsExtra := 2,
-@AIName     := "SmartAI",
+@AIName     := "",
 @Script     := "";
 
 -- NPC

--- a/StoneyJamal.sql
+++ b/StoneyJamal.sql
@@ -17,7 +17,7 @@ SET
 @Type       := 7,
 @TypeFlags  := 0,
 @FlagsExtra := 2,
-@AIName     := "SmartAI",
+@AIName     := "",
 @Script     := "";
 
 -- NPC

--- a/TrickyJohn.sql
+++ b/TrickyJohn.sql
@@ -17,7 +17,7 @@ SET
 @Type       := 7,
 @TypeFlags  := 0,
 @FlagsExtra := 2,
-@AIName     := "SmartAI",
+@AIName     := "",
 @Script     := "";
 
 -- NPC

--- a/VelvetyJosh.sql
+++ b/VelvetyJosh.sql
@@ -17,7 +17,7 @@ SET
 @Type       := 7,
 @TypeFlags  := 0,
 @FlagsExtra := 2,
-@AIName     := "SmartAI",
+@AIName     := "",
 @Script     := "";
 
 -- NPC


### PR DESCRIPTION
The SmartAI Flag is not needed, because the vendors dont move trough the world.